### PR TITLE
bugfix in validation when tucking with multiple yarns

### DIFF
--- a/fnitout.mjs
+++ b/fnitout.mjs
@@ -335,7 +335,7 @@ export function validate(instructions) {
 				if (instruction.yarns.length > 0) {
 					const n = instruction.needle.toString();
 					if (!(n in state.loops)) state.loops[n] = instruction.yarns.length;
-					else state.loops[n] += 1;
+					else state.loops[n] += instruction.yarns.length;
 				}
 				setAttachments(); //update attached loops
 				setYarns(); //move carriers


### PR DESCRIPTION
Jenny, could you check this? It doesn't seem right to increment the loop count by 1 when tucking with multiple yarns. But I could be wrong.