### PR TITLE
Error in k2f.mjs

### DIFF
--- a/k2f.mjs
+++ b/k2f.mjs
@@ -372,7 +372,7 @@ for ( ; lineIndex < lines.length; ++lineIndex) {
 			if (cs.length === 0) {
 				emit(`xfer ${n.bed}.${n.index} ${t.bed}.${t.index}`);
 			} else {
-				emit(`split ${d} ${n.bed}.${n.index} ${stitchSize} ${yarns.join(' ')}`);
+				emit(`split ${d} ${n.bed}.${n.index} ${t.bed}.${t.index} ${stitchSize} ${yarns.join(' ')}`);
 			}
 			const keyT = `${t.bed}.${t.index}`;
 			if (!(keyT in loops)) loops[keyT] = loops[keyN];


### PR DESCRIPTION
Split instructions are missing the target needle in the output file.

The example files don't need to be remade because they contain no split operations.